### PR TITLE
Make CapacityUsage last update age threshold configurable. Backward compatible change.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ optional arguments:
   --password PASSWORD, -p PASSWORD
                         Password for Basic Auth
   --mode MODE, -m MODE  Check mode
+  --max-age MAX_AGE, -M MAX_AGE
+                        Max age in minutes for capacity usage updates. Defaults to 5
+  --version, -V         Print version
   --insecure            Do not verify TLS certificate. Be careful with this option, please
 ```
 


### PR DESCRIPTION
According to our Ops team the CapacityUsage on our NSX-T environments updates every hour and this is fine. I don't know what the reasoning was behind the original 5 minutes threshold, or what should be the default behavior for NSX-T but thought I'd add a small modification to make it easily configurable. It's an optional argument and if you don't supply it it defaults to the current value of 5 minutes. Thanks for providing this check!