### PR TITLE
Extend perfdata

### DIFF
--- a/check_vmware_nsxt.py
+++ b/check_vmware_nsxt.py
@@ -397,11 +397,11 @@ def commandline(args):
     parser.add_argument('--password', '-p',
                         help='Password for Basic Auth', required=True)
     parser.add_argument('--mode', '-m', choices=['cluster-status', 'alarms', 'capacity-usage'],
-                        help='Check mode to exectue', required=True)
+                        help='Check mode to exectue. Hint: alarms will only include open alarms.', required=True)
     parser.add_argument('--max-age', '-M', type=int,
                         help='Max age in minutes for capacity usage updates. Defaults to 5', default=5, required=False)
     parser.add_argument('--insecure',
-                        help='Do not verify TLS certificate. Be careful with this option, please', action='store_true', required=False)
+                        help='Do not verify TLS certificate', action='store_true', required=False)
     parser.add_argument('--version', '-V',
                         help='Print version', action='store_true')
 

--- a/check_vmware_nsxt.py
+++ b/check_vmware_nsxt.py
@@ -263,6 +263,8 @@ class Alarms(CheckResult):
 
         for state, value in states.items():
             self.summary.append("%d %s" % (value, state.lower()))
+            self.perfdata.append("alarms.%s=%d;;;0" % (state.lower(), value))
+
 
     def build_status(self):
         states = []

--- a/test_check_vmware_nsxt.py
+++ b/test_check_vmware_nsxt.py
@@ -151,7 +151,7 @@ class ClientTesting(unittest.TestCase):
         expected = 1
 
         self.assertEqual(actual, expected)
-        mock_print.assert_called_with('[WARNING] 1 alarms - 1 medium\n\n[MEDIUM] (2021-04-26 15:25:18) (node1) Intelligence Health/Storage Latency High - Intelligence node storage latency is high.\n| alarms=1;;;0')
+        mock_print.assert_called_with('[WARNING] 1 alarms - 1 medium\n\n[MEDIUM] (2021-04-26 15:25:18) (node1) Intelligence Health/Storage Latency High - Intelligence node storage latency is high.\n| alarms=1;;;0 alarms.medium=1;;;0')
 
     @mock.patch('builtins.print')
     @mock.patch('requests.request')


### PR DESCRIPTION
This PR extends the perfdata for alarms
    
- Now includes count by alarm severity

Also improves the help message for alarms.

See #10 