### PR TITLE
Switch main shebang to python3

### DIFF
--- a/check_vmware_nsxt.py
+++ b/check_vmware_nsxt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 # coding:utf-8
 """
 Icinga check plugin for VMware NSX-T

--- a/check_vmware_nsxt.py
+++ b/check_vmware_nsxt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # coding:utf-8
 """
 Icinga check plugin for VMware NSX-T


### PR DESCRIPTION
Since the plugin only runs on python3, that might as well be reflected by the shebang. Also removed the indirection with `/usr/bin/env`, if the path to `env` is known, the path to `python3` should also be known.